### PR TITLE
Add skip_notify attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 network_interface
 =================
 
+v1.0.2 (2017-05-15)
+-------------------
+- Provide option to prevent notification of if_up after interface changes
+
 v1.0.0 (2014-03-03)
 -------------------
-
 - released version on community
 
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'guilhem.lettron@youscribe.com'
 license 'Apache 2.0'
 description 'Installs/Configures network on Ubuntu and Debian'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.0.1'
+version '1.0.2'
 
 supports 'ubuntu', '>= 12.04'
 supports 'debian', '>= 6.0.8'

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -64,7 +64,7 @@ action :save do
       post_down:    Chef::Recipe::NetworkInterfaces.value(:post_down,  new_resource.device, new_resource, node),
       custom:       Chef::Recipe::NetworkInterfaces.value(:custom,     new_resource.device, new_resource, node)
     )
-    notifies :run, "execute[if_up #{new_resource.name}]", :immediately
+    notifies :run, "execute[if_up #{new_resource.name}]", :immediately unless new_resource.skip_notify
     notifies :create, 'ruby_block[Merge interfaces]', :delayed
   end
 

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -5,25 +5,26 @@ end
 
 actions :save, :remove
 
-attribute :device,     kind_of: String, name_attribute: true
-attribute :bridge,     kind_of: [TrueClass, FalseClass, Array]
-attribute :bridge_stp, kind_of: [TrueClass, FalseClass]
-attribute :bond,       kind_of: [TrueClass, FalseClass, Array]
-attribute :bond_mode,  kind_of: String
-attribute :vlan_dev,   kind_of: String
-attribute :onboot,     kind_of: [TrueClass, FalseClass], default: true
-attribute :bootproto,  kind_of: String
-attribute :target,     kind_of: String
-attribute :gateway,    kind_of: String
-attribute :metric,     kind_of: Integer
-attribute :mtu,        kind_of: Integer
-attribute :mask,       kind_of: String
-attribute :network,    kind_of: String
-attribute :broadcast,  kind_of: String
-attribute :pre_up,     kind_of: String
-attribute :up,         kind_of: String
-attribute :post_up,    kind_of: String
-attribute :pre_down,   kind_of: String
-attribute :down,       kind_of: String
-attribute :post_down,  kind_of: String
-attribute :custom,     kind_of: Hash
+attribute :device,        kind_of: String, name_attribute: true
+attribute :bridge,        kind_of: [TrueClass, FalseClass, Array]
+attribute :bridge_stp,    kind_of: [TrueClass, FalseClass]
+attribute :bond,          kind_of: [TrueClass, FalseClass, Array]
+attribute :bond_mode,     kind_of: String
+attribute :vlan_dev,      kind_of: String
+attribute :onboot,        kind_of: [TrueClass, FalseClass], default: true
+attribute :bootproto,     kind_of: String
+attribute :target,        kind_of: String
+attribute :gateway,       kind_of: String
+attribute :metric,        kind_of: Integer
+attribute :mtu,           kind_of: Integer
+attribute :mask,          kind_of: String
+attribute :network,       kind_of: String
+attribute :broadcast,     kind_of: String
+attribute :pre_up,        kind_of: String
+attribute :up,            kind_of: String
+attribute :post_up,       kind_of: String
+attribute :pre_down,      kind_of: String
+attribute :down,          kind_of: String
+attribute :post_down,     kind_of: String
+attribute :custom,        kind_of: Hash
+attribute :skip_notify,   kind_of: [TrueClass, FalseClass], default: false


### PR DESCRIPTION
Allow a resource to opt out of having its network interface reloaded on
a config change. The alternative can be extremely painful if the machine
is serving live traffic, so deferring the reload can prevent downtime.